### PR TITLE
webpack: Add babel (ES6/ES2015) loader.

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,2 +1,20 @@
-var elem = document.getElementById("js-status");
-elem.innerHTML = "Javascript working";
+// ES6 module import/export check
+import utils from "./utils";
+
+const js_status = document.getElementById("js-status");
+const js_es6_check = document.getElementById("js-es6-check");
+const js_module_check = document.getElementById("js-module-check");
+
+const es6 = "ES2015/ES6";
+const x = 5;
+const y = 10;
+
+js_status.innerHTML = "Javascript working!";
+
+// Check if es6 template literal works.
+js_es6_check.innerHTML = `JS version: ${es6}`;
+
+let add_result = utils.add(x, y);
+let arrow_add_result = utils.arrow_add(x, y);
+
+js_module_check.innerHTML = `ES6 modules working: ${add_result == arrow_add_result}`;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,6 +12,8 @@
 <body>
   <div>HTML working</div>
   <div id="js-status"></div>
+  <div id="js-es6-check"></div>
+  <div id="js-module-check"></div>
 </body>
 
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,9 @@
     "devDependencies": {
         "webpack": "^2.2.1",
         "html-loader": "^0.4.4",
-        "html-webpack-plugin": "^2.28.0"
+        "html-webpack-plugin": "^2.28.0",
+        "babel-core": "^6.23.1",
+        "babel-loader": "^6.3.2",
+        "babel-preset-es2015": "^6.22.0"
     }
 }

--- a/frontend/utils.js
+++ b/frontend/utils.js
@@ -1,0 +1,12 @@
+function add(a, b) {
+    return a + b;
+}
+
+let arrow_add = (a, b) => a + b;
+
+let utils = {
+    add,
+    arrow_add
+};
+
+export default utils;

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -16,6 +16,15 @@ module.exports = {
             {
                 test: /\.html$/,
                 loader: "html-loader"
+            }, {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                loader: "babel-loader",
+                options: {
+                    presets: [
+                        ["es2015", { modules: false }]
+                    ]
+                }
             }
         ]
     },


### PR DESCRIPTION
This allows our frontend code to be written in ES2015 and get transpiled into ES5 by Webpack.