### PR TITLE
frontend: Use singleton pattern for main THREE.js objects.

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5,25 +5,38 @@ import * as THREE from 'three';
 import milligramCss from 'milligram';
 import customCss from './style.css';
 
-import globals from './globals';
+import {globals as g} from './globals';
 
-const scene = new THREE.Scene();
-const camera = new THREE.OrthographicCamera(
-    globals.leftCoord, globals.rightCoord,
-    globals.topCoord, globals.bottomCoord,
+let initialWidth = window.innerWidth;
+let initialHeight = window.innerHeight;
+
+g.scene = new THREE.Scene();
+g.camera = new THREE.OrthographicCamera(
+    -initialWidth / 2, initialWidth / 2,
+    -initialHeight / 2, initialHeight / 2,
     1, 1000
 );
-const renderer = new THREE.WebGLRenderer({
+g.renderer = new THREE.WebGLRenderer({
     antialias: true
 });
-
-renderer.setSize(globals.winWidth, globals.winHeight);
-document.body.appendChild(renderer.domElement);
+g.renderer.setSize(initialWidth, initialHeight);
 
 const render = function () {
     requestAnimationFrame(render);
-
-    renderer.render(scene, camera);
+    g.renderer.render(g.scene, g.camera);
 };
 
+window.addEventListener('resize', () => {
+    let width = window.innerWidth;
+    let height = window.innerHeight;
+
+    g.renderer.setSize(width, height);
+    g.camera.left = -width / 2;
+    g.camera.right = width / 2;
+    g.camera.top = height / 2;
+    g.camera.bottom = -height / 2;
+    g.camera.updateProjectionMatrix();
+}, false);
+
+document.body.appendChild(g.renderer.domElement);
 render();

--- a/frontend/globals.js
+++ b/frontend/globals.js
@@ -1,18 +1,17 @@
-const winHeight = window.innerHeight;
-const winWidth = window.innerWidth;
+export const title = 'Soundzcape';
+export const version = '0.1.0';
 
-const leftCoord = -winWidth / 2;
-const rightCoord = winWidth / 2;
-const topCoord = winHeight / 2;
-const bottomCoord = -winHeight / 2;
+let instance = null;
 
-const globals = {
-    winHeight,
-    winWidth,
-    leftCoord,
-    rightCoord,
-    topCoord,
-    bottomCoord
-};
+// We use the singleton design pattern to store the main THREE.js objects.
+class Globals {
+    constructor() {
+        if (!instance) {
+            instance = this;
+        }
 
-export default globals;
+        return instance;
+    }
+}
+
+export const globals = new Globals();


### PR DESCRIPTION
This allows a single instantiated object to be imported and modify in
any modules.